### PR TITLE
Update sideEffect parameters to enable dry run

### DIFF
--- a/environments/elastic/elastic-operator/elastic-operator.yaml
+++ b/environments/elastic/elastic-operator/elastic-operator.yaml
@@ -3440,6 +3440,7 @@ webhooks:
       path: /validate-agent-k8s-elastic-co-v1alpha1-agent
   failurePolicy: Ignore
   name: elastic-agent-validation-v1alpha1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - agent.k8s.elastic.co
@@ -3476,6 +3477,7 @@ webhooks:
       path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
   failurePolicy: Ignore
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - apm.k8s.elastic.co
@@ -3494,6 +3496,7 @@ webhooks:
       path: /validate-beat-k8s-elastic-co-v1beta1-beat
   failurePolicy: Ignore
   name: elastic-beat-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - beat.k8s.elastic.co
@@ -3512,6 +3515,7 @@ webhooks:
       path: /validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch
   failurePolicy: Ignore
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - enterprisesearch.k8s.elastic.co
@@ -3530,6 +3534,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
   failurePolicy: Ignore
   name: elastic-es-validation-v1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co
@@ -3548,6 +3553,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
   failurePolicy: Ignore
   name: elastic-es-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co
@@ -3566,6 +3572,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1-kibana
   failurePolicy: Ignore
   name: elastic-kb-validation-v1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - kibana.k8s.elastic.co
@@ -3584,6 +3591,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
   failurePolicy: Ignore
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - kibana.k8s.elastic.co

--- a/environments/elastic/elastic-operator/validate-webhook.jsonnet
+++ b/environments/elastic/elastic-operator/validate-webhook.jsonnet
@@ -20,6 +20,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-agent-validation-v1alpha1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [
@@ -78,6 +79,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-apm-validation-v1beta1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [
@@ -107,6 +109,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-beat-validation-v1beta1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [
@@ -136,6 +139,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-ent-validation-v1beta1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [
@@ -165,6 +169,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-es-validation-v1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [
@@ -194,6 +199,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-es-validation-v1beta1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [
@@ -223,6 +229,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-kb-validation-v1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [
@@ -252,6 +259,7 @@
       },
       failurePolicy: 'Ignore',
       name: 'elastic-kb-validation-v1beta1.k8s.elastic.co',
+      sideEffects: 'None',
       rules: [
         {
           apiGroups: [


### PR DESCRIPTION
Mentioned in https://github.com/elastic/cloud-on-k8s/pull/3181.
We need to specify this parameter to enable client side dry run.